### PR TITLE
✨ feat: api호출 하여 받아온 데이터 가공

### DIFF
--- a/src/@types/api.d.ts
+++ b/src/@types/api.d.ts
@@ -1,6 +1,7 @@
 declare module 'request' {
   type ApiUrlType = '/media' | '/advertisements' | '/report';
   interface ReportInterface {
+    dataType: 'Report' | 'Media';
     imp: number;
     click: number;
     cost: number;
@@ -35,6 +36,7 @@ declare module 'request' {
   }
 
   interface MediaInterface {
+    dataType: 'Report' | 'Media';
     channel: string;
     date: string;
 
@@ -53,5 +55,12 @@ declare module 'request' {
   interface TotalDataManagementInterface {
     reports: ReportInterface[];
     media: MediaInterface[];
+  }
+
+  interface TotalData {
+    [date: string]: {
+      reports: ReportInterface[];
+      media: MediaInterface[];
+    };
   }
 }

--- a/src/@types/api.d.ts
+++ b/src/@types/api.d.ts
@@ -57,7 +57,7 @@ declare module 'request' {
     media: MediaInterface[];
   }
 
-  interface TotalData {
+  interface TotalDataInterface {
     [date: string]: {
       reports: ReportInterface[];
       media: MediaInterface[];

--- a/src/@types/api.d.ts
+++ b/src/@types/api.d.ts
@@ -1,7 +1,8 @@
 declare module 'request' {
   type ApiUrlType = '/media' | '/advertisements' | '/report';
+  type ApiDataType = 'Report' | 'Media';
   interface ReportInterface {
-    dataType: 'Report' | 'Media';
+    dataType: ApiDataType;
     imp: number;
     click: number;
     cost: number;
@@ -36,7 +37,7 @@ declare module 'request' {
   }
 
   interface MediaInterface {
-    dataType: 'Report' | 'Media';
+    dataType: ApiDataType;
     channel: string;
     date: string;
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,13 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Router from '@/routes';
+import { useTotalDataManagement } from './api/models/useTotalDataManagement';
 
 function App() {
+  const { weekList, getTotalData } = useTotalDataManagement();
+  useEffect(() => {
+    console.log('Apprender');
+  }, []);
+
   return <Router />;
 }
 

--- a/src/api/models/useTotalDataManagement.ts
+++ b/src/api/models/useTotalDataManagement.ts
@@ -20,15 +20,15 @@ export const useTotalDataManagement = () => {
       ]);
 
       const reportsFormattedData = dateFormat(reportsResponse);
-      const MediaFormattedData = dateFormat(mediaResponse);
+      const mediaFormattedData = dateFormat(mediaResponse);
 
       setTotalData({
         reports: reportsFormattedData,
-        media: MediaFormattedData,
+        media: mediaFormattedData,
       });
 
-      console.log(createWeeklyList(reportsFormattedData, MediaFormattedData));
-      setWeekList(createWeekList(reportsFormattedData, MediaFormattedData));
+      console.log(createWeeklyList(reportsFormattedData, mediaFormattedData));
+      setWeekList(createWeekList(reportsFormattedData, mediaFormattedData));
     } catch (error) {
       console.log(error);
       /* alert('데이터를 불러오는데 실패 하였습니다. 관리자에게 문의하세요'); */

--- a/src/api/models/useTotalDataManagement.ts
+++ b/src/api/models/useTotalDataManagement.ts
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { TotalDataManagementInterface } from 'request';
 import { apiRequest } from '../instance';
 import createWeekList from '@/utils/createWeekList';
+import createWeeklyList from '@/utils/createWeeklyList';
 
 export const useTotalDataManagement = () => {
   const [totalData, setTotalData] = useState<TotalDataManagementInterface>({
@@ -18,17 +19,19 @@ export const useTotalDataManagement = () => {
         apiRequest.get('/media'),
       ]);
 
-      const reportsData = dateFormat(reportsResponse);
-      const mediaData = dateFormat(mediaResponse);
+      const reportsFormattedData = dateFormat(reportsResponse);
+      const MediaFormattedData = dateFormat(mediaResponse);
 
       setTotalData({
-        reports: reportsData,
-        media: mediaData,
+        reports: reportsFormattedData,
+        media: MediaFormattedData,
       });
-      setWeekList(createWeekList(reportsData, mediaData));
+
+      console.log(createWeeklyList(reportsFormattedData, MediaFormattedData));
+      setWeekList(createWeekList(reportsFormattedData, MediaFormattedData));
     } catch (error) {
       console.log(error);
-      alert('데이터를 불러오는데 실패 하였습니다. 관리자에게 문의하세요');
+      /* alert('데이터를 불러오는데 실패 하였습니다. 관리자에게 문의하세요'); */
     }
   };
 

--- a/src/components/DropDownMenu/index.tsx
+++ b/src/components/DropDownMenu/index.tsx
@@ -16,7 +16,6 @@ const DropDownMenu = () => {
   const clickedWeekList = (event: React.MouseEvent<HTMLElement>) => {
     console.log(event.currentTarget.textContent);
   };
-
   return (
     <PopupState variant="popover" popupId="demo-popup-menu">
       {(popupState) => (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,3 +1,2 @@
 export { default as DashboardPage } from './DashboardPage';
 export { default as ManagementPage } from './ManagementPage';
-export { default as DrawerTest } from './DrawerTest';

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Route, Routes, Navigate } from 'react-router-dom';
 import Layout from '@/components/Layout';
-import { DashboardPage, ManagementPage, DrawerTest } from '@/pages';
+import { DashboardPage, ManagementPage } from '@/pages';
 
 const Router = () => {
   return (

--- a/src/utils/createWeekList.ts
+++ b/src/utils/createWeekList.ts
@@ -11,7 +11,7 @@ const getStartDateOfWeek = (date: string) => {
   let dataFns = new Date(date);
   let startDate = '';
   if (isMonday(dataFns)) {
-    return (startDate = format(new Date(date), 'yyyy년MM월dd일'));
+    startDate = format(new Date(date), 'yyyy년MM월dd일');
   } else {
     startDate = format(previousMonday(new Date(date)), 'yyyy년MM월dd일');
   }

--- a/src/utils/createWeekList.ts
+++ b/src/utils/createWeekList.ts
@@ -11,7 +11,7 @@ const getStartDateOfWeek = (date: string) => {
   let dataFns = new Date(date);
   let startDate = '';
   if (isMonday(dataFns)) {
-    startDate = format(new Date(date), 'yyyy년MM월dd일');
+    return (startDate = format(new Date(date), 'yyyy년MM월dd일'));
   } else {
     startDate = format(previousMonday(new Date(date)), 'yyyy년MM월dd일');
   }
@@ -29,7 +29,7 @@ const getEndDateOfWeek = (date: string) => {
   return endDate;
 };
 
-const makeWeekList = (date: string, weekArray: Array<string>) => {
+const makeWeekList = (date: string, weekArray: string[]) => {
   const startDateOfWeek = getStartDateOfWeek(date);
   const endDateOfWeek = getEndDateOfWeek(date);
   const periodOfWeek = `${startDateOfWeek} ~ ${endDateOfWeek}`;
@@ -53,7 +53,6 @@ const createWeekList = (
     makeWeekList(media.date, weekArray);
   });
 
-  console.log(weekArray);
   return weekArray;
 };
 

--- a/src/utils/createWeeklyList.ts
+++ b/src/utils/createWeeklyList.ts
@@ -1,0 +1,162 @@
+import {
+  format,
+  isMonday,
+  previousMonday,
+  isSunday,
+  nextSunday,
+  getUnixTime,
+} from 'date-fns';
+import { MediaInterface, ReportInterface, TotalData } from 'request';
+
+type CombineDataType = ReportInterface | MediaInterface;
+
+const addTypeAndYearMonthDate = (
+  data: CombineDataType,
+  dataType: 'Report' | 'Media'
+) => {
+  const date = new Date(data.date);
+  const yearMonthDate = format(date, 'yyyy년MM월dd일');
+  const monthDate = format(date, 'MM월dd일');
+
+  return { ...data, yearMonthDate, monthDate, dataType };
+};
+
+const sortData = (
+  combineDataA: CombineDataType,
+  combineDataB: CombineDataType
+) => {
+  const unixTimeA = getUnixTime(new Date(combineDataA.date));
+  const unixTimeB = getUnixTime(new Date(combineDataB.date));
+
+  return unixTimeB - unixTimeA;
+};
+
+const combineData = (
+  reportData: ReportInterface[],
+  mediaData: MediaInterface[]
+) => {
+  const combinedData: CombineDataType[] = [];
+  reportData.forEach((report) => {
+    combinedData.push(addTypeAndYearMonthDate(report, 'Report'));
+  });
+
+  mediaData.forEach((media) => {
+    combinedData.push(addTypeAndYearMonthDate(media, 'Media'));
+  });
+
+  combinedData.sort(sortData);
+
+  return combinedData;
+};
+
+const multiDimensionalUnique = (dateList: string[][]) => {
+  const uniques = [];
+  const itemsFound: { [key: string]: boolean } = {};
+
+  for (const date of dateList) {
+    const stringified = JSON.stringify(date);
+    if (itemsFound[stringified]) continue;
+    uniques.push(date);
+    itemsFound[stringified] = true;
+  }
+
+  return uniques;
+};
+
+const getStartDateOfWeek = (date: string) => {
+  let startDate = new Date(date);
+  if (isMonday(startDate))
+    return [
+      format(startDate, 'yyyy-MM-dd'),
+      format(startDate, 'yyyy년MM월dd일'),
+    ];
+
+  return [
+    format(previousMonday(startDate), 'yyyy-MM-dd'),
+    format(previousMonday(startDate), 'yyyy년MM월dd일'),
+  ];
+};
+
+const getEndDateOfWeek = (date: string) => {
+  let endDate = new Date(date);
+  if (isSunday(endDate))
+    return [format(endDate, 'yyyy-MM-dd'), format(endDate, 'yyyy년MM월dd일')];
+
+  return [
+    format(nextSunday(endDate), 'yyyy-MM-dd'),
+    format(nextSunday(endDate), 'yyyy년MM월dd일'),
+  ];
+};
+
+const makeWeekList = (date: string) => {
+  const [startDate, startDateOfWeek] = getStartDateOfWeek(date);
+  const [endDate, endDateOfWeek] = getEndDateOfWeek(date);
+  const periodOfWeek = `${startDateOfWeek} ~ ${endDateOfWeek}`;
+
+  return { periodOfWeek, startDate, endDate };
+};
+
+const makeDeduplicatedDateList = (combinedData: CombineDataType[]) => {
+  const dateList: string[][] = [];
+  [...new Set(combinedData.map((data) => data.date))].forEach((data) => {
+    const { periodOfWeek, startDate, endDate } = makeWeekList(data);
+    dateList.push([periodOfWeek, startDate, endDate]);
+  });
+
+  return multiDimensionalUnique(dateList);
+};
+
+const checkBetweenStartAndEndDate = ({
+  date,
+  startDate,
+  endDate,
+}: {
+  date: string;
+  startDate: string;
+  endDate: string;
+}) => {
+  return (
+    getUnixTime(new Date(date)) >= getUnixTime(new Date(startDate)) &&
+    getUnixTime(new Date(date)) <= getUnixTime(new Date(endDate))
+  );
+};
+
+const setWeeklyData = (
+  dataList: string[][],
+  combinedData: CombineDataType[]
+) => {
+  const weeklyData: TotalData = {};
+
+  dataList.forEach(([periodOfWeek, startDate, endDate]) => {
+    const reportData = combinedData.filter(
+      (data) =>
+        data.dataType === 'Report' &&
+        checkBetweenStartAndEndDate({ date: data.date, startDate, endDate })
+    );
+
+    const mediaData = combinedData.filter(
+      (data) =>
+        data.dataType === 'Media' &&
+        checkBetweenStartAndEndDate({ date: data.date, startDate, endDate })
+    );
+
+    weeklyData[periodOfWeek] = {
+      reports: reportData as ReportInterface[],
+      media: mediaData as MediaInterface[],
+    };
+  });
+
+  return weeklyData;
+};
+
+const createWeeklyList = (
+  reportData: ReportInterface[],
+  mediaData: MediaInterface[]
+) => {
+  const combinedData = combineData(reportData, mediaData);
+  const dataList = makeDeduplicatedDateList(combinedData);
+
+  return setWeeklyData(dataList, combinedData);
+};
+
+export default createWeeklyList;

--- a/src/utils/createWeeklyList.ts
+++ b/src/utils/createWeeklyList.ts
@@ -6,7 +6,7 @@ import {
   nextSunday,
   getUnixTime,
 } from 'date-fns';
-import { MediaInterface, ReportInterface, TotalData } from 'request';
+import { MediaInterface, ReportInterface, TotalDataInterface } from 'request';
 
 type CombineDataType = ReportInterface | MediaInterface;
 
@@ -125,7 +125,7 @@ const setWeeklyData = (
   dataList: string[][],
   combinedData: CombineDataType[]
 ) => {
-  const weeklyData: TotalData = {};
+  const weeklyData: TotalDataInterface = {};
 
   dataList.forEach(([periodOfWeek, startDate, endDate]) => {
     const reportData = combinedData.filter(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "isolatedModules": true, //각 파일을 분리된 모듈로 트랜스파일
     "baseUrl": "./", // Non-relativ 모듈 혹은 paths 옵션의 기준 디렉토리
     "resolveJsonModule": true, // 타입스크립트에서 json모듈 import 되도록 허용
+    "downlevelIteration": true,
     "paths": {
       // baseUrl 옵션을 기준디렉토리로 불러올 모듈의 위치 설정이 가능
       "@/*": ["src/*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "isolatedModules": true, //각 파일을 분리된 모듈로 트랜스파일
     "baseUrl": "./", // Non-relativ 모듈 혹은 paths 옵션의 기준 디렉토리
     "resolveJsonModule": true, // 타입스크립트에서 json모듈 import 되도록 허용
-    "downlevelIteration": true,
+    "downlevelIteration": true, //target이 es6 이전 버전인 경우에 이터러블 프로토콜을 사용 할 수 있도록 해줌
     "paths": {
       // baseUrl 옵션을 기준디렉토리로 불러올 모듈의 위치 설정이 가능
       "@/*": ["src/*"]


### PR DESCRIPTION
## 😲 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
<!-- [] 안에 소문자 엑스(x)를 넣으면 체크표시가 활성화됩니다! ex) [x] -->
- [x] 기능 추가
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

## 😎 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
<!-- 메인 페이지의 lazy loading을 ~을 이용하여 구현하였다. 등의 이야기를 작성해주세요 :) -->
1. 통합광고현황(report)데이터 와 매체현황(media)데이터를 취합합니다.
2. 최신데이터 부터 보여주기 위해 날짜 기준 내림차순으로 데이터를 정렬 합니다.
3. 취합된 데이터를 날짜 데이터만 추출하여 중복을 제거해서 새로운 날짜 리스트를 만듭니다.
4. 주간마다 데이터를 통합광고현황(report)데이터 와 매체현황(media)데이터 로 각각 분리하여 취합합니다.

![대시보드데이터](https://user-images.githubusercontent.com/23183352/179417321-0d359645-3ae2-47be-85dc-49421ef7e329.PNG)


## 🥳 성장 포인트 (기능 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
<!-- Hook의 중요성을 다시금 깨닫게 되었다 등의 사소한 내용까지도! 편하게 작성해주세요 XD -->
다차원 배열의 중복을 제거하는 방법에 대해 알게 되었습니다.

## 🤔 기타 질문 및 특이 사항
<!-- @@ 부분 코드가 너무 복잡한 것 같은데 더 줄일 수 있는 방법이 없을까요? 같은 고민되는 내용을 마구 공유해주세요! -->
일단 현재는 첫 요청시 데이터를 전부 받아와 취합하고 그 이후엔 쿼리스트링으로 지속적으로 요청하여 주간별 데이터를 가져옵니다. 저 방법도 좋지만 그냥 개인적으로 데이터를 한번의 요청으로 받아서 가공을 해놓으면 더이상의 요청없이 딱 한번만의 요청만 필요로 하기 때문에 보다 효율적이라고 생각해서 만들어 보았습니다. 