### PR TITLE
✨ feat: 주간 드롭다운 선택에 따라 Line차트에 데이터 적용

### DIFF
--- a/src/api/models/useReportModel.ts
+++ b/src/api/models/useReportModel.ts
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { apiRequest } from '@/api/instance';
-import { AxiosResponse } from 'axios';
 import { ReportInterface } from 'request';
 import dateFormat from '@/utils/dateFormat';
 export const useReportModel = () => {
@@ -12,7 +11,8 @@ export const useReportModel = () => {
     setReports(formattedData);
   };
 
-  const getWeekReports = async (startDate: string, endDate: string) => {
+  const getWeekReports = async (datesOfWeek: string[]) => {
+    const [startDate, endDate] = datesOfWeek;
     const response = await apiRequest.get(
       '/report',
       `date_gte=${startDate}&date_lte=${endDate}`

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -5,8 +5,13 @@ import MenuItem from '@mui/material/MenuItem';
 import styled from 'styled-components';
 import PopupState, { bindTrigger, bindMenu } from 'material-ui-popup-state';
 import { useTotalDataManagement } from '@/api/models/useTotalDataManagement';
+import changeOriginalDateFormat from '@/utils/changeOriginalDateFormat';
 
-const DropDownMenu = () => {
+interface DropdownProps {
+  getSpecificWeekData: (datesOfWeek: string[]) => void;
+}
+
+const Dropdown = ({ getSpecificWeekData }: DropdownProps) => {
   const { weekList, getTotalData } = useTotalDataManagement();
 
   useEffect(() => {
@@ -14,7 +19,8 @@ const DropDownMenu = () => {
   }, []);
 
   const clickedWeekList = (event: React.MouseEvent<HTMLElement>) => {
-    console.log(event.currentTarget.textContent);
+    const selectedDate = event.currentTarget.textContent as string;
+    getSpecificWeekData(changeOriginalDateFormat(selectedDate));
   };
 
   return (
@@ -27,11 +33,7 @@ const DropDownMenu = () => {
           <StyledMenu {...bindMenu(popupState)}>
             {weekList.map((week, index) => {
               return (
-                <StyledMenuItem
-                  key={index}
-                  onClick={clickedWeekList}
-                  style={{ fontSize: '12px' }}
-                >
+                <StyledMenuItem key={index} onClick={clickedWeekList}>
                   {week}
                 </StyledMenuItem>
               );
@@ -46,10 +48,10 @@ const DropDownMenu = () => {
 const StyledMenu = styled(Menu)`
   height: 200px;
   div {
-    left: 0px !important;
+    /* left: 0px !important; */
   }
 `;
 const StyledMenuItem = styled(MenuItem)`
-  font-size: 14px;
+  font-size: 12px;
 `;
-export default DropDownMenu;
+export default Dropdown;

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -18,7 +18,7 @@ const Dropdown = ({ getSpecificWeekData }: DropdownProps) => {
     getTotalData();
   }, []);
 
-  const clickedWeekList = (event: React.MouseEvent<HTMLElement>) => {
+  const clickedWeekList = (event: React.MouseEvent<HTMLLIElement>) => {
     const selectedDate = event.currentTarget.textContent as string;
     getSpecificWeekData(changeOriginalDateFormat(selectedDate));
   };

--- a/src/components/Report/index.tsx
+++ b/src/components/Report/index.tsx
@@ -10,17 +10,23 @@ import {
 } from 'recharts';
 import { ReportInterface } from 'request';
 import styled from 'styled-components';
-import DropDownMenu from '@/components/DropDownMenu';
+import DropDownMenu from '@/components/Dropdown';
 import Summary from './Summary';
+import { useReportModel } from '@/api/models/useReportModel';
 
 interface ReportProps {
   data: ReportInterface[];
 }
 
 const Report = ({ data }: ReportProps) => {
+  const { reports, getWeekReports } = useReportModel();
+  const getSpecificWeekData = (datesOfWeek: string[]) => {
+    getWeekReports(datesOfWeek);
+  };
+
   return (
     <>
-      <DropDownMenu />
+      <DropDownMenu getSpecificWeekData={getSpecificWeekData} />
       <Container>
         <SummaryContainer>
           <Summary />
@@ -30,7 +36,11 @@ const Report = ({ data }: ReportProps) => {
           <Summary />
           <Summary />
         </SummaryContainer>
-        <LineChart width={1000} height={250} data={data}>
+        <LineChart
+          width={1000}
+          height={250}
+          data={reports.length ? reports : data}
+        >
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="monthDate" style={{ fontSize: '14px' }} />
           <YAxis />

--- a/src/utils/changeOriginalDateFormat.ts
+++ b/src/utils/changeOriginalDateFormat.ts
@@ -1,0 +1,7 @@
+const changeOriginalDateFormat = (date: string): string[] => {
+  date = date.replace(/[년월]/g, '-');
+  date = date.replace(/[일]/g, '');
+  return date.split(' ~ ');
+};
+
+export default changeOriginalDateFormat;

--- a/src/utils/createWeekList.ts
+++ b/src/utils/createWeekList.ts
@@ -7,13 +7,15 @@ import {
 } from 'date-fns';
 import { ReportInterface, MediaInterface } from 'request';
 
+const KOREAN_DATE_FORMAT = 'yyyy년MM월dd일';
+
 const getStartDateOfWeek = (date: string) => {
   let dataFns = new Date(date);
   let startDate = '';
   if (isMonday(dataFns)) {
-    startDate = format(new Date(date), 'yyyy년MM월dd일');
+    startDate = format(new Date(date), KOREAN_DATE_FORMAT);
   } else {
-    startDate = format(previousMonday(new Date(date)), 'yyyy년MM월dd일');
+    startDate = format(previousMonday(new Date(date)), KOREAN_DATE_FORMAT);
   }
   return startDate;
 };
@@ -22,9 +24,9 @@ const getEndDateOfWeek = (date: string) => {
   let dataFns = new Date(date);
   let endDate = '';
   if (isSunday(dataFns)) {
-    endDate = format(new Date(date), 'yyyy년MM월dd일');
+    endDate = format(new Date(date), KOREAN_DATE_FORMAT);
   } else {
-    endDate = format(nextSunday(new Date(date)), 'yyyy년MM월dd일');
+    endDate = format(nextSunday(new Date(date)), KOREAN_DATE_FORMAT);
   }
   return endDate;
 };
@@ -53,7 +55,6 @@ const createWeekList = (
     makeWeekList(media.date, weekArray);
   });
 
-  console.log(weekArray);
   return weekArray;
 };
 


### PR DESCRIPTION
## 😲 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
<!-- [] 안에 소문자 엑스(x)를 넣으면 체크표시가 활성화됩니다! ex) [x] -->
- [x] 기능 추가
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

## 😎 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
* 드롭다운 주간 변경에 따라 해당 데이터가 차트에 그려지도록 했습니다.
![data-change](https://user-images.githubusercontent.com/18342765/179431224-4e4bf300-53c5-4ffc-8b7c-ba218de95caf.gif)

## 🥳 성장 포인트 (기능 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
* 드롭다운의 값에 따라 데이터를 페칭하고 차트를 그릴 수 있게 되었습니다.

## 🤔 기타 질문 및 특이 사항
* 드롭다운 선택에 따른 데이터페칭 및 차트 그리는 과정에서 유저가 다른 액션을 하지 못하도록 `Loading` 처리가 필요할 것 같습니다.
* 여력이 된다면 이미 받아온 데이터에 대해서 또 요청하지 않도록 캐싱하는 방법에 대해 고려해보면 좋겠습니다. (react-query 신기하더군요!!)
